### PR TITLE
feat: add comprehensive API documentation with Sphinx and TypeDoc

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -62,11 +62,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e python/
           pip install mkdocs mkdocs-material mkdocs-swagger-ui-tag
+          pip install sphinx sphinx-rtd-theme sphinx-autoapi myst-parser
 
       - name: Install TypeScript dependencies
         run: |
           cd typescript
           npm install
+          npm install --save-dev typedoc typedoc-plugin-markdown
 
       - name: Generate protobuf code
         run: |
@@ -86,6 +88,35 @@ jobs:
 
       - name: Generate API documentation
         run: |
+          # Generate Python API documentation with Sphinx
+          mkdir -p docs/generated/python
+          cd python
+          sphinx-quickstart --quiet --project "PostFiat Python SDK" --author "PostFiat" --version "1.0" --release "1.0" --language en --suffix .rst --master index --ext-autodoc --ext-viewcode --makefile --no-batchfile docs/
+          
+          # Configure Sphinx for autoapi
+          cat >> docs/conf.py << 'EOF'
+          extensions.append('autoapi.extension')
+          autoapi_dirs = ['../postfiat']
+          autoapi_type = 'python'
+          autoapi_file_patterns = ['*.py']
+          autoapi_options = ['members', 'undoc-members', 'show-inheritance', 'show-module-summary', 'imported-members']
+          autoapi_template_dir = '_templates/autoapi'
+          autoapi_add_toctree_entry = False
+          html_theme = 'sphinx_rtd_theme'
+          EOF
+          
+          # Build Python docs
+          cd docs
+          make html
+          cp -r _build/html/* ../../docs/generated/python/
+          cd ../..
+          
+          # Generate TypeScript API documentation with TypeDoc
+          mkdir -p docs/generated/typescript
+          cd typescript
+          npx typedoc --out ../docs/generated/typescript src/index.ts --plugin typedoc-plugin-markdown --theme markdown
+          cd ..
+          
           # Copy generated OpenAPI specs
           mkdir -p docs/generated/api
           if [ -d "api" ]; then
@@ -140,6 +171,8 @@ jobs:
             - Contributing: CONTRIBUTING.md
             - API Reference:
               - OpenAPI Specification: api/openapi.md
+              - Python SDK: generated/python/index.html
+              - TypeScript SDK: generated/typescript/README.md
               - Protocol Buffers: generated/proto/index.md
             - Research:
               - Key Management: research/KEY-MANAGEMENT.md
@@ -198,6 +231,13 @@ jobs:
           - **Type-safe**: Generated types and validation
           - **Modern tooling**: FastAPI, Pydantic, React hooks
           - **AI integration**: PydanticAI support for agents
+          
+          ## API Documentation
+          
+          - **[Python SDK API](generated/python/index.html)** - Complete Python API reference with Sphinx
+          - **[TypeScript SDK API](generated/typescript/README.md)** - TypeScript API documentation with TypeDoc
+          - **[OpenAPI Specification](api/openapi.md)** - Interactive REST API documentation
+          - **[Protocol Buffers](generated/proto/index.md)** - Proto message definitions
           
           ## Architecture
           


### PR DESCRIPTION
- Add Sphinx for Python API documentation with autoapi
- Add TypeDoc for TypeScript API documentation
- Generate complete API reference for both SDKs
- Include navigation to Python, TypeScript, OpenAPI, and Proto docs
- Use professional documentation themes (RTD for Python)
- Auto-generate from source code docstrings and comments

🤖 Generated with [Claude Code](https://claude.ai/code)