### PR TITLE
fix: properly handle generated code documentation with import error h…

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -129,8 +129,11 @@ jobs:
           autoapi_dirs = ['../postfiat']
           autoapi_type = 'python'
           autoapi_file_patterns = ['*.py']
-          autoapi_options = ['members', 'undoc-members', 'show-inheritance', 'show-module-summary', 'imported-members']
+          autoapi_options = ['members', 'undoc-members', 'show-inheritance', 'show-module-summary']
           autoapi_add_toctree_entry = False
+          autoapi_keep_files = True
+          autoapi_root = 'api'
+          autoapi_python_use_implicit_namespaces = True
           
           html_theme = 'sphinx_rtd_theme'
           html_static_path = []
@@ -159,9 +162,18 @@ jobs:
           * :ref:\`search\`
           EOF
           
-          # Build Python docs
+          # Build Python docs with better error handling
           cd docs
-          sphinx-build -b html . _build/html
+          export PYTHONPATH="/home/runner/work/pfsdk/pfsdk/python:$PYTHONPATH"
+          sphinx-build -b html . _build/html || {
+              echo "Sphinx build failed, trying with autodoc mock imports"
+              cat >> conf.py << 'EOF'
+          
+          # Mock imports for generated modules that might have import issues
+          autodoc_mock_imports = ['grpc', 'google.protobuf', 'a2a']
+          EOF
+              sphinx-build -b html . _build/html
+          }
           cp -r _build/html/* ../../docs/generated/python/
           cd ../..
           


### PR DESCRIPTION
…andling

- Add PYTHONPATH export to ensure proper module resolution
- Add fallback with autodoc_mock_imports for problematic imports
- Use implicit namespaces for better import handling
- Keep autoapi_keep_files to preserve generated documentation
- Document BOTH manual and generated code as intended

🤖 Generated with [Claude Code](https://claude.ai/code)