### PR TITLE
fix: enable autoapi toctree integration for Sphinx docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -130,7 +130,7 @@ jobs:
           autoapi_type = 'python'
           autoapi_file_patterns = ['*.py']
           autoapi_options = ['members', 'undoc-members', 'show-inheritance', 'show-module-summary']
-          autoapi_add_toctree_entry = False
+          autoapi_add_toctree_entry = True
           autoapi_keep_files = True
           autoapi_root = 'api'
           autoapi_python_use_implicit_namespaces = True
@@ -141,18 +141,12 @@ jobs:
           master_doc = 'index'
           EOF
           
-          # Create index file
+          # Create index file - autoapi will add itself to toctree
           cat > docs/index.rst << EOF
           PostFiat Python SDK Documentation
           =================================
           
           Welcome to the PostFiat Python SDK documentation.
-          
-          .. toctree::
-             :maxdepth: 2
-             :caption: Contents:
-          
-             api/index
           
           Indices and tables
           ==================


### PR DESCRIPTION
## Summary
- Set `autoapi_add_toctree_entry = True` to let AutoAPI automatically add itself to the toctree
- Simplified index.rst to remove manual toctree reference that was causing build failures
- AutoAPI will now automatically generate proper navigation structure

## Test plan
- [x] Documentation workflow should now pass
- [x] Sphinx will automatically include API documentation in navigation
- [x] Generated API docs will be properly integrated

🤖 Generated with [Claude Code](https://claude.ai/code)