### PR TITLE
fix: resolve TypeScript compilation errors in documentation build

### DIFF
--- a/typescript/src/hooks/PostFiatProvider.tsx
+++ b/typescript/src/hooks/PostFiatProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, ReactNode } from 'react';
+import { createContext, useContext, ReactNode } from 'react';
 import { PostFiatClient } from '../sdk/client';
 import type { ClientOptions } from '../sdk/config';
 

--- a/typescript/src/hooks/index.tsx
+++ b/typescript/src/hooks/index.tsx
@@ -12,7 +12,7 @@ import { PostFiatError } from '../types/exceptions';
 /**
  * PostFiat client context
  */
-const PostFiatClientContext = createContext<PostFiatClient | null>(null);
+export const PostFiatClientContext = createContext<PostFiatClient | null>(null);
 
 /**
  * PostFiat client provider props


### PR DESCRIPTION
## Summary
- Fixed `'React' is declared but its value is never read` error in PostFiatProvider.tsx
- Fixed `Cannot find namespace 'PostFiatClientContext'` error by exporting the context
- These fixes should resolve the TypeScript compilation errors in the documentation workflow

## Test plan
- [x] TypeScript compilation should now pass
- [x] TypeDoc documentation generation should succeed  
- [x] Documentation workflow should complete successfully

🤖 Generated with [Claude Code](https://claude.ai/code)