### PR TITLE
fix: resolve React hooks export and JSX compilation issues

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -12,7 +12,7 @@
     "!**/*.spec.ts"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
+    "build": "tsup",
     "dev": "tsup src/index.ts --format esm --watch",
     "test": "jest",
     "test:coverage": "jest --coverage",

--- a/typescript/scripts/generate-typescript-types.ts
+++ b/typescript/scripts/generate-typescript-types.ts
@@ -649,7 +649,6 @@ export function useAsyncOperation<T>(): [
  * Hook for wallet operations
  */
 export function useWallet() {
-  const client = usePostFiatClient();
   const [walletState, executeWalletOperation] = useAsyncOperation<any>();
 
   const createWallet = useCallback(async (request: any) => {
@@ -679,7 +678,6 @@ export function useWallet() {
  * Hook for message operations
  */
 export function useMessages() {
-  const client = usePostFiatClient();
   const [messageState, executeMessageOperation] = useAsyncOperation<any>();
 
   const sendMessage = useCallback(async (message: any) => {
@@ -755,7 +753,7 @@ export function useSubscription<T>(
 `;
 
   // Write the generated file
-  const outputPath = path.join(__dirname, '..', 'src', 'hooks', 'index.ts');
+  const outputPath = path.join(__dirname, '..', 'src', 'hooks', 'index.tsx');
   const outputDir = path.dirname(outputPath);
   
   if (!fs.existsSync(outputDir)) {
@@ -821,8 +819,8 @@ export * from './types/exceptions';
 // Client utilities
 export * from './client/base';
 
-// React hooks (optional peer dependency) - commented out due to JSX build issues
-// export * from './hooks';
+// React hooks (optional peer dependency)
+export * from './hooks';
 
 // Generated protobuf types and services
 export * from './generated';

--- a/typescript/src/hooks/index.tsx
+++ b/typescript/src/hooks/index.tsx
@@ -12,7 +12,7 @@ import { PostFiatError } from '../types/exceptions';
 /**
  * PostFiat client context
  */
-export const PostFiatClientContext = createContext<PostFiatClient | null>(null);
+const PostFiatClientContext = createContext<PostFiatClient | null>(null);
 
 /**
  * PostFiat client provider props

--- a/typescript/tsup.config.ts
+++ b/typescript/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  clean: true,
+  external: ['react', 'react-dom'],
+  esbuildOptions: (options) => {
+    options.jsx = 'automatic';
+    options.jsxImportSource = 'react';
+  },
+  tsconfig: './tsconfig.json',
+});


### PR DESCRIPTION
- Enable React hooks export in main index.ts
- Change React hooks file to .tsx extension for proper JSX compilation
- Configure tsup to handle JSX with automatic runtime
- Fix TypeScript unused variable warnings in generated hooks
- Add proper type-only imports to avoid runtime import issues

This resolves the missing usePostFiatClient and PostFiatClientProvider exports that applications need for React integration.