### PR TITLE
Fix header search and theme toggle

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ theme:
         icon: material/brightness-4
         name: Switch to light mode
   features:
+    - announce.dismiss
     - navigation.tabs
     - navigation.sections
     - navigation.top

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,17 +1,7 @@
 {% extends "base.html" %}
 
-{% block banner %}
+{% block announce %}
   {% if config.extra.release_url %}
-  <aside class="md-banner">
-    <div class="md-banner__inner md-grid md-typeset">
-      <div class="md-announce">
-        <div class="md-announce__inner">
-          <a href="{{ config.extra.release_url }}" class="md-announce__link">
-            🎉 Latest Release: {{ config.extra.release_tag }} - Download Now!
-          </a>
-        </div>
-      </div>
-    </div>
-  </aside>
+    🎉 Latest Release: <a href="{{ config.extra.release_url }}">{{ config.extra.release_tag }}</a> - Download Now!
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
- **Fixed template structure**: Changed `overrides/main.html` to use the `announce` block instead of the `banner` block
- **Enabled proper styling**: Added `announce.dismiss` feature to `mkdocs.yml` for native Material theme styling
- **Restored full header**: Search bar, theme toggle, and all other header elements now work properly

- Modified `overrides/main.html` to use Material for MkDocs announce block pattern
- Added `announce.dismiss` feature in `mkdocs.yml` for proper banner styling
- Removed custom HTML classes in favor of Material theme defaults
